### PR TITLE
Added option to use maximum number of video frames

### DIFF
--- a/R/calibrateCameras.R
+++ b/R/calibrateCameras.R
@@ -410,7 +410,12 @@ calibrateCameras <- function(img.dir, sq.size, nx, ny, cal.file, corner.dir,
 
 		}else if(img_type %in% c('video', 'video frames')){
 
-			if(num.aspects.read == 'auto') num.aspects.read <- 60
+			if(num.aspects.read == 'auto') {
+				num.aspects.read <- 60
+			}
+			else if(num.aspects.read == 'max') {
+				num.aspects.read <- min(vid_nframes) - 40
+			}
 
 			# GET MINIMUM NUMBER OF FRAMES AMONG ALL VIDEOS
 			min_nframes <- min(vid_nframes)


### PR DESCRIPTION
I had some calibration video files with few and sparse frames that had detectable corners. I added this small bit of code to calibrateCameras.R that allows for using the entire video instead of sampling.