### PR TITLE
Fixed infinite loop issue with nlminb

### DIFF
--- a/R/estimateDistortion.R
+++ b/R/estimateDistortion.R
@@ -14,13 +14,13 @@ estimateDistortion <- function(undistort.params, img.size){
 	# Try different starting parameters
 	p_start <- list(
 		rep(0, 5),
-		c(0.1, NA, NA, NA, NA),
-		c(0.1, 0.01, NA, NA, NA),
-		c(0.14, 0.006, 0.002, NA, NA),
-		c(0.1, 0.01, 1e-5, NA, NA),
+		c(0.1),
+		c(0.1, 0.01),
+		c(0.14, 0.006, 0.002),
+		c(0.1, 0.01, 1e-5),
 		#c(0.1, 0.01, 1e-5, -1e-5, -0.1),
-		c(0.01, -0.001, 1e-5, NA, NA),
-		c(0.01, 0.1, -1e-5, NA, NA)
+		c(0.01, -0.001, 1e-5),
+		c(0.01, 0.1, -1e-5)
 	)
 	
 	# Save with each try
@@ -53,6 +53,7 @@ estimateDistortion <- function(undistort.params, img.size){
 	
 	# Get parameter from run with the lowest error (including no distortion case)
 	p <- par[[which.min(objectives)]]
+	p <- c(p, rep(NA, 7 - length(p)))
 	
 	# Add names to parameters
 	names(p) <- c('cx', 'cy', 'k1', 'k2', 'k3', 'p1', 'p2')

--- a/R/estimateUndistortion.R
+++ b/R/estimateUndistortion.R
@@ -21,13 +21,13 @@ estimateUndistortion <- function(coor.2d, cal.nx, image.size){
 	# TRY DIFFERENT STARTING PARAMETERS
 	p_start <- list(
 		rep(0, 5),
-		c(0.1, NA, NA, NA, NA),
-		c(0.1, 0.01, NA, NA, NA),
-		c(0.14, 0.006, 0.002, NA, NA),
-		c(0.1, 0.01, 1e-5, NA, NA),
+		c(0.1),
+		c(0.1, 0.01),
+		c(0.14, 0.006, 0.002),
+		c(0.1, 0.01, 1e-5),
 		#c(0.1, 0.01, 1e-5, -1e-5, -0.1),
-		c(0.01, -0.001, 1e-5, NA, NA),
-		c(0.01, 0.1, -1e-5, NA, NA)
+		c(0.01, -0.001, 1e-5),
+		c(0.01, 0.1, -1e-5)
 	)
 	
 	# SAVE WITH EACH TRY
@@ -60,6 +60,7 @@ estimateUndistortion <- function(coor.2d, cal.nx, image.size){
 	
 	# GET PARAMETERS FROM RUN WITH LOWEST ERROR (INCLUDING NO DISTORTION CASE)
 	dist_params <- par[[which.min(objectives)]]
+	dist_params <- c(dist_params, rep(NA, 7 - length(dist_params)))
 	
 	# ADD NAMES TO PARAMETERS
 	names(dist_params) <- c('cx', 'cy', 'k1', 'k2', 'k3', 'p1', 'p2')


### PR DESCRIPTION
At least as of R 4.3, passing NA's to the start parameters for `nlminb` will result in an infinite loop. I removed the NA's from the starting parameter list, and the code works fine. Thankfully, accessing non-existent elements in R also returns NA's, so no downstream code is impacted by the change.